### PR TITLE
LOAP-3103 | Add name attribute to daData input

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -271,7 +271,8 @@ var ReactDadata = function (_React$Component) {
           customInput = _props.customInput,
           placeholder = _props.placeholder,
           showNote = _props.showNote,
-          styles = _props.styles;
+          styles = _props.styles,
+          name = _props.name;
 
 
       var showSuggestionsList = inputFocused && showSuggestions;
@@ -285,7 +286,8 @@ var ReactDadata = function (_React$Component) {
         onKeyDown: this.onKeyPress,
         placeholder: placeholder,
         value: query,
-        autoFocus: autoFocus || false
+        autoFocus: autoFocus || false,
+        name: name || 'daData'
       };
 
       return React.createElement(
@@ -514,7 +516,8 @@ ReactDadata.propTypes = {
   silentQuery: _propTypes2.default.string,
   style: _propTypes2.default.objectOf(_propTypes2.default.string),
   token: _propTypes2.default.string.isRequired,
-  type: _propTypes2.default.string
+  type: _propTypes2.default.string,
+  name: _propTypes2.default.string
 };
 
 ReactDadata.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -346,7 +346,8 @@ class ReactDadata extends React.Component {
       customInput,
       placeholder,
       showNote,
-      styles
+      styles,
+      name
     } = this.props;
 
     const showSuggestionsList = inputFocused && showSuggestions;
@@ -361,6 +362,7 @@ class ReactDadata extends React.Component {
       placeholder: placeholder,
       value: query,
       autoFocus: autoFocus || false,
+      name: name || 'daData'
     };
 
     return (
@@ -410,7 +412,8 @@ ReactDadata.propTypes = {
   silentQuery: PropTypes.string,
   style: PropTypes.objectOf(PropTypes.string),
   token: PropTypes.string.isRequired,
-  type: PropTypes.string
+  type: PropTypes.string,
+  name: PropTypes.string,
 };
 
 ReactDadata.defaultProps = {


### PR DESCRIPTION
To accomplish the task https://kredito.atlassian.net/browse/LOAP-3103 we need to add the `name` prop to `daData`, so we will be able to recognize which input we need to get to move the focus there.  