### PR TITLE
LOAP-3267 | Limit amount of requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ To translate
 | silentQuery | Not | string | Подстрока для запроса в DaData, которая применяется если свойство **query** не передано или является пустой строкой, оно не отображается в поле ввода, и в этом случае определяет список значений при раскрытии списка | |
 | token | Yes | string | Authorization Token DaData.ru | |
 | type | Not | string | Type of data to be requested: address (address), organization (party) or bank (bank), mail (email), name (fio), passport (fms_unit) | "address" |
-| minimumCharacterThreshold | Not | number | minimum number of characters entered after which a first request is sent | 3 |
+| name | Not | string | Property name of input | daData |
+| minimumCharacterThreshold | Not | number | Minimum number of characters entered after which a first request is sent | 3 |
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To translate
 | customActions | Not | ReactNode &#124; function [return: ReactNode] | Возможность добавления произвольных действия\[-ий\](элемента\[-ов\]) в конец базового выпадающего списка. Если устанавливается как функция, то принимает на вход полученный перечень вариантов(suggestions) в качестве аргумента. Каждый элемент (если в итоге предоставляется массив) - оборачивается в стандартный контейнер для отдельно взятого suggestion | |
 | customEndpoint | Not | string &#124; object | Указать нестандартный URI для запроса подсказок (для использования в сценарии проксирования или при разворачивании сервиса локально в своей инфраструктуре); Если строка - рассматрривается как полный адрес хоста или относительный путь от корня текущего сайта (адрес api будет подставлен автоматически см. значение по умолчанию), если объект, то подразумевается наличие полей 'host' и/или 'api', опущенные значения будут подставленны из значения по умолчанию |{<br/>&nbsp;&nbsp;host: 'https://suggestions.dadata.ru',<br/>&nbsp;&nbsp;api: 'suggestions/api/4_1/rs/suggest'<br/>}|
 | customInput | Not | function | Функция принимающая на вход props типового пол ввода, и позволяющая установить кастомный input-компонент или компонент с аналогичной сигнатурой | `(params) => <input { ...params } />`
-| debounce | Not | number | Time of debouncing a service call for search bar changes | 350 мс|
+| debounce | Not | number | Time of debouncing a service call for search bar changes | 350 ms |
 | onChange | Not | function | Function called when selecting an option from list | |
 | onIdleOut | Not | function | Функция, вызываемая при изменении строки поиска, если по текущей подстроке не найдено вариантов подсказки, принимая текущую строку поиска как аргумент | |
 | payloadModifier | Not | object &#124; function | Объект модифицирующий отправляемый payload ({...nativePayload, ...payloadModifier}}), или функция формирующая отправляемый payload, принимает аргументом объект payload формируемый компонентом для модификации. (Таким образом можно формировать и устанавливать дополнительные параметы н/п фильтрацию) | |
@@ -50,6 +50,7 @@ Clone the repository
 `npm start`
 
 #### Build
-??
+
 `npm run transpile`
+and commit the `dist` directory to origin.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Clone the repository
 
 #### Build
 
-`npm run transpile`
+`npm run build`
 and commit the `dist` directory to origin.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To translate
 | silentQuery | Not | string | Подстрока для запроса в DaData, которая применяется если свойство **query** не передано или является пустой строкой, оно не отображается в поле ввода, и в этом случае определяет список значений при раскрытии списка | |
 | token | Yes | string | Authorization Token DaData.ru | |
 | type | Not | string | Type of data to be requested: address (address), organization (party) or bank (bank), mail (email), name (fio), passport (fms_unit) | "address" |
+| minimumCharacterThreshold | Not | number | minimum number of characters entered after which a first request is sent | 3 |
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To translate
 | silentQuery | Not | string | Подстрока для запроса в DaData, которая применяется если свойство **query** не передано или является пустой строкой, оно не отображается в поле ввода, и в этом случае определяет список значений при раскрытии списка | |
 | token | Yes | string | Authorization Token DaData.ru | |
 | type | Not | string | Type of data to be requested: address (address), organization (party) or bank (bank), mail (email), name (fio), passport (fms_unit) | "address" |
+| autoFocus | Not | boolean | Add autofocus to the input field | false |
 | name | Not | string | Property name of input | daData |
 | minimumCharacterThreshold | Not | number | Minimum number of characters entered after which a first request is sent | 3 |
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -334,8 +334,8 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.componentDidUpdate = function (prevProps) {
-    if (_this2.props.query !== prevProps.query) {
-      _this2.setState({ query: _this2.props.query }, _this2.fetchSuggestions);
+    if (_this2.props.query !== prevProps.query && _this2.props.query !== _this2.state.query) {
+      _this2.setState({ query: _this2.props.query }, _this2.onPropsQueryUpdate);
     }
   };
 
@@ -380,6 +380,23 @@ var _initialiseProps = function _initialiseProps() {
     }
 
     _this2.setState({ query: value, showSuggestions: true }, function () {
+      _this2.debounce(_this2.fetchSuggestions, _this2.props.debounce)({ inputFocused: true, showSuggestions: true });
+    });
+  };
+
+  this.onPropsQueryUpdate = function () {
+    var query = _this2.state.query;
+
+    if (query.length === 0) {
+      return _this2.clear();
+    }
+
+    if (query.length < 3) {
+      clearTimeout(_this2.debounceTimer);
+      return _this2.setState({ showSuggestions: false });
+    }
+
+    _this2.setState({ showSuggestions: true }, function () {
       _this2.debounce(_this2.fetchSuggestions, _this2.props.debounce)({ inputFocused: true, showSuggestions: true });
     });
   };

--- a/dist/index.js
+++ b/dist/index.js
@@ -542,8 +542,8 @@ ReactDadata.propTypes = {
   style: _propTypes2.default.objectOf(_propTypes2.default.string),
   token: _propTypes2.default.string.isRequired,
   type: _propTypes2.default.string,
-  minimumCharacterThreshold: _propTypes2.default.number,
-  name: _propTypes2.default.string
+  name: _propTypes2.default.string,
+  minimumCharacterThreshold: _propTypes2.default.number
 };
 
 ReactDadata.defaultProps = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -368,13 +368,14 @@ var _initialiseProps = function _initialiseProps() {
 
   this.onInputChange = function (event) {
     var value = event.target.value;
+    var minimumCharacterThreshold = _this2.props.minimumCharacterThreshold;
 
 
     if (value.length === 0) {
       return _this2.clear();
     }
 
-    if (value.length < 3) {
+    if (value.length < minimumCharacterThreshold) {
       clearTimeout(_this2.debounceTimer);
       return _this2.setState({ query: value, showSuggestions: false });
     }
@@ -386,12 +387,14 @@ var _initialiseProps = function _initialiseProps() {
 
   this.onPropsQueryUpdate = function () {
     var query = _this2.state.query;
+    var minimumCharacterThreshold = _this2.props.minimumCharacterThreshold;
+
 
     if (query.length === 0) {
       return _this2.clear();
     }
 
-    if (query.length < 3) {
+    if (query.length < minimumCharacterThreshold) {
       clearTimeout(_this2.debounceTimer);
       return _this2.setState({ showSuggestions: false });
     }
@@ -536,13 +539,15 @@ ReactDadata.propTypes = {
   silentQuery: _propTypes2.default.string,
   style: _propTypes2.default.objectOf(_propTypes2.default.string),
   token: _propTypes2.default.string.isRequired,
-  type: _propTypes2.default.string
+  type: _propTypes2.default.string,
+  minimumCharacterThreshold: _propTypes2.default.number
 };
 
 ReactDadata.defaultProps = {
   customInput: function customInput(params) {
     return React.createElement('input', params);
-  }
+  },
+  minimumCharacterThreshold: 3
 };
 
 exports.default = ReactDadata;

--- a/dist/index.js
+++ b/dist/index.js
@@ -429,7 +429,6 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.fetchSuggestions = function (setStateAdditional) {
-    console.log('fetching suggestions');
     _this2.xhr.abort();
 
     var type = _this2.state.type;

--- a/dist/index.js
+++ b/dist/index.js
@@ -359,9 +359,7 @@ var _initialiseProps = function _initialiseProps() {
         args[_key2] = arguments[_key2];
       }
 
-      if (_this2.debounceTimer) {
-        clearTimeout(_this2.debounceTimer);
-      }
+      clearTimeout(_this2.debounceTimer);
       _this2.debounceTimer = setTimeout(function () {
         func.apply(undefined, args);
       }, cooldown);
@@ -372,11 +370,18 @@ var _initialiseProps = function _initialiseProps() {
     var value = event.target.value;
 
 
+    if (value.length === 0) {
+      return _this2.clear();
+    }
+
+    if (value.length < 3) {
+      clearTimeout(_this2.debounceTimer);
+      return _this2.setState({ query: value, showSuggestions: false });
+    }
+
     _this2.setState({ query: value, showSuggestions: true }, function () {
       _this2.debounce(_this2.fetchSuggestions, _this2.props.debounce)({ inputFocused: true, showSuggestions: true });
     });
-
-    !value && _this2.clear();
   };
 
   this.onKeyPress = function (event) {
@@ -407,6 +412,7 @@ var _initialiseProps = function _initialiseProps() {
   };
 
   this.fetchSuggestions = function (setStateAdditional) {
+    console.log('fetching suggestions');
     _this2.xhr.abort();
 
     var type = _this2.state.type;

--- a/examples/App.js
+++ b/examples/App.js
@@ -23,7 +23,6 @@ class App extends Component {
   };
 
   render() {
-    console.log('state', this.state.selectedValues);
     return (
       <div>
         {/* <input placeholder="адрес" value={this.state.value} onChange={this.handleType} />

--- a/examples/App.js
+++ b/examples/App.js
@@ -25,16 +25,23 @@ class App extends Component {
   render() {
     return (
       <div>
-        {/* <input placeholder="адрес" value={this.state.value} onChange={this.handleType} />
-        <ReactDadataBox
-          className="data"
-          token={token}
-          placeholder="Адрес"
-          type="address"
-          query={this.state.value}
-          onChange={this.handleChange}
-          allowClear
-        /> */}
+        <div style={{ background: 'aliceblue', padding: '10px 5px' }}>
+          <input
+            placeholder="Enter to simulate props to dadata input"
+            value={this.state.value}
+            onChange={this.handleType}
+            style={{ width: '100%', boxSizing: 'border-box' }}
+          />
+          <ReactDadataBox
+            className="data"
+            token={token}
+            placeholder="Аddress"
+            type="address"
+            query={this.state.value}
+            onChange={this.handleChange}
+            allowClear
+          />
+        </div>
         <ReactDadataBox
           className="data"
           token={token}

--- a/examples/App.js
+++ b/examples/App.js
@@ -81,6 +81,15 @@ class App extends Component {
         <ReactDadataBox
           className="data"
           token={token}
+          placeholder="Address with request after 10 characters"
+          type="address"
+          city={true}
+          onChange={this.handleSelectedValue('address')}
+          minimumCharacterThreshold={10}
+        />
+        <ReactDadataBox
+          className="data"
+          token={token}
           placeholder="Passport"
           type="fms_unit"
           city={true}

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,6 +153,7 @@ interface BaseInputProps<T = HTMLInputElement> {
  * @property  { boolean } allowClear - [optional] show/hide clear fieldd control
  * @property  { boolean } showNote - [optional] show/hide note at suggestions list
  * @property  { boolean } silentQuery - [optional] initial query that not showed on input but determine  suggestion list that showed at first
+ * @property  { string } name - [optional] - property name of input (default: "daData")
  * @property  { number } minimumCharacterThreshold - [optional] minimum number of characters entered after which a first request is sent (default: 3)
  */
 
@@ -181,6 +182,7 @@ interface Props {
   allowClear?: boolean;
   showNote?: boolean;
   silentQuery?: string;
+  name?: string;
   minimumCharacterThreshold?: number;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,6 +153,7 @@ interface BaseInputProps<T = HTMLInputElement> {
  * @property  { boolean } allowClear - [optional] show/hide clear fieldd control
  * @property  { boolean } showNote - [optional] show/hide note at suggestions list
  * @property  { boolean } silentQuery - [optional] initial query that not showed on input but determine  suggestion list that showed at first
+ * @property  { boolean } autoFocus - [optional] add autofocus to the input field (default: false)
  * @property  { string } name - [optional] - property name of input (default: "daData")
  * @property  { number } minimumCharacterThreshold - [optional] minimum number of characters entered after which a first request is sent (default: 3)
  */
@@ -182,6 +183,7 @@ interface Props {
   allowClear?: boolean;
   showNote?: boolean;
   silentQuery?: string;
+  autoFocus?: boolean;
   name?: string;
   minimumCharacterThreshold?: number;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ interface BaseInputProps<T = HTMLInputElement> {
  * @property  { onChange } onChange - [optional] - onChange handler
  * @property  { onIdleOut } onIdleOut - [optional] - onIdleOut handler, fires with one argument - current query, when by this query has not returned suggestions
  * @property  { object | function } payloadModifier - [optional] - object to patch payload or function returned payload object to send, that has auto generated payload object as argument
- * @property  { debounce } onChange - [optional] - debounce to onChange handler (default: 350 ms).
+ * @property  { debounce } onChange - [optional] - debounce to onChange handler (default: 350 ms)
  * @property  { string } placeholder - [optional] - placeholder
  * @property  { string } query - [optional] - query for search
  * @property  { React.CSSProperties } style - [optional] - custom styling
@@ -153,6 +153,7 @@ interface BaseInputProps<T = HTMLInputElement> {
  * @property  { boolean } allowClear - [optional] show/hide clear fieldd control
  * @property  { boolean } showNote - [optional] show/hide note at suggestions list
  * @property  { boolean } silentQuery - [optional] initial query that not showed on input but determine  suggestion list that showed at first
+ * @property  { number } minimumCharacterThreshold - [optional] minimum number of characters entered after which a first request is sent (default: 3)
  */
 
 interface Props {
@@ -180,6 +181,7 @@ interface Props {
   allowClear?: boolean;
   showNote?: boolean;
   silentQuery?: string;
+  minimumCharacterThreshold?: number;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "webpack-dev-server",
-    "transpile": "NODE_ENV=production babel src -d dist --copy-files",
-    "prepublishOnly": "npm run transpile"
+    "build": "NODE_ENV=production babel src -d dist --copy-files",
+    "prepublishOnly": "npm run build"
   },
   "author": {
     "name": "orbita",

--- a/src/index.js
+++ b/src/index.js
@@ -273,7 +273,6 @@ class ReactDadata extends React.Component {
   };
 
   fetchSuggestions = setStateAdditional => {
-    console.log('fetching suggestions');
     this.xhr.abort();
 
     const { type } = this.state;

--- a/src/index.js
+++ b/src/index.js
@@ -221,12 +221,13 @@ class ReactDadata extends React.Component {
 
   onInputChange = event => {
     const { value } = event.target;
+    const { minimumCharacterThreshold } = this.props;
 
     if (value.length === 0) {
       return this.clear();
     }
 
-    if (value.length < 3) {
+    if (value.length < minimumCharacterThreshold) {
       clearTimeout(this.debounceTimer);
       return this.setState({ query: value, showSuggestions: false });
     }
@@ -238,11 +239,13 @@ class ReactDadata extends React.Component {
 
   onPropsQueryUpdate = () => {
     const { query } = this.state;
+    const { minimumCharacterThreshold } = this.props;
+
     if (query.length === 0) {
       return this.clear();
     }
 
-    if (query.length < 3) {
+    if (query.length < minimumCharacterThreshold) {
       clearTimeout(this.debounceTimer);
       return this.setState({ showSuggestions: false });
     }
@@ -431,11 +434,13 @@ ReactDadata.propTypes = {
   silentQuery: PropTypes.string,
   style: PropTypes.objectOf(PropTypes.string),
   token: PropTypes.string.isRequired,
-  type: PropTypes.string
+  type: PropTypes.string,
+  minimumCharacterThreshold: PropTypes.number,
 };
 
 ReactDadata.defaultProps = {
-  customInput: params => <input {...params} />
+  customInput: params => <input {...params} />,
+  minimumCharacterThreshold: 3
 };
 
 export default ReactDadata;

--- a/src/index.js
+++ b/src/index.js
@@ -187,8 +187,8 @@ class ReactDadata extends React.Component {
   };
 
   componentDidUpdate = prevProps => {
-    if (this.props.query !== prevProps.query) {
-      this.setState({ query: this.props.query }, this.fetchSuggestions);
+    if (this.props.query !== prevProps.query && this.props.query !== this.state.query) {
+      this.setState({ query: this.props.query }, this.onPropsQueryUpdate);
     }
   };
 
@@ -232,6 +232,22 @@ class ReactDadata extends React.Component {
     }
 
     this.setState({ query: value, showSuggestions: true }, () => {
+      this.debounce(this.fetchSuggestions, this.props.debounce)({ inputFocused: true, showSuggestions: true });
+    });
+  };
+
+  onPropsQueryUpdate = () => {
+    const { query } = this.state;
+    if (query.length === 0) {
+      return this.clear();
+    }
+
+    if (query.length < 3) {
+      clearTimeout(this.debounceTimer);
+      return this.setState({ showSuggestions: false });
+    }
+
+    this.setState({ showSuggestions: true }, () => {
       this.debounce(this.fetchSuggestions, this.props.debounce)({ inputFocused: true, showSuggestions: true });
     });
   };

--- a/src/index.js
+++ b/src/index.js
@@ -437,8 +437,8 @@ ReactDadata.propTypes = {
   style: PropTypes.objectOf(PropTypes.string),
   token: PropTypes.string.isRequired,
   type: PropTypes.string,
-  minimumCharacterThreshold: PropTypes.number,
-  name: PropTypes.string
+  name: PropTypes.string,
+  minimumCharacterThreshold: PropTypes.number
 };
 
 ReactDadata.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -212,9 +212,7 @@ class ReactDadata extends React.Component {
 
   debounce = (func, cooldown = 350) => {
     return (...args) => {
-      if (this.debounceTimer) {
-        clearTimeout(this.debounceTimer);
-      }
+      clearTimeout(this.debounceTimer);
       this.debounceTimer = setTimeout(() => {
         func(...args);
       }, cooldown);
@@ -224,11 +222,18 @@ class ReactDadata extends React.Component {
   onInputChange = event => {
     const { value } = event.target;
 
+    if (value.length === 0) {
+      return this.clear();
+    }
+
+    if (value.length < 3) {
+      clearTimeout(this.debounceTimer);
+      return this.setState({ query: value, showSuggestions: false });
+    }
+
     this.setState({ query: value, showSuggestions: true }, () => {
       this.debounce(this.fetchSuggestions, this.props.debounce)({ inputFocused: true, showSuggestions: true });
     });
-
-    !value && this.clear();
   };
 
   onKeyPress = event => {
@@ -252,6 +257,7 @@ class ReactDadata extends React.Component {
   };
 
   fetchSuggestions = setStateAdditional => {
+    console.log('fetching suggestions');
     this.xhr.abort();
 
     const { type } = this.state;
@@ -360,7 +366,7 @@ class ReactDadata extends React.Component {
       onKeyDown: this.onKeyPress,
       placeholder: placeholder,
       value: query,
-      autoFocus: autoFocus || false,
+      autoFocus: autoFocus || false
     };
 
     return (


### PR DESCRIPTION
### Purpose
Right now we send too many requests to dadata.

### Approach
* Update `componentDidUpdate` so that it has the same rules as input on change handler. 
* Don't send request with empty query (e.g. backspacing)
* Send request after a certain number of characters is entered

### Extra
* Rename `transpile` to `build` - it is more aligned with our other repos.